### PR TITLE
Add script to help export to graphite

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,39 @@ python ./multiple_dumps_multiple_files.py --file-prefix ./target/pe_metrics/pupp
 The results are currently written to the `./target` directory - open up
 `report.html` in your browser.
 
-### Metrics from Older PE Installations
+### Metrics from older PE installations
 
-Some older installations of PE (e.g. 2016.1.2) do not log data expected by the visualizer scripts. As a work-around, you can run the included `patch_files.rb` script to create versions of the json files with injected dummy data, so that they can be processed and visualized anyway.
+Some older installations of PE (e.g. 3.8) do not log data expected by the visualizer scripts. As a work-around, you can run the included `patch_files.rb` script to create versions of the json files with injected dummy data, so that they can be processed and visualized anyway.
 
 Usage:
 
     ./patch_files.rb [filename_1 ... filename_n]
 
-Example:
+Examples:
 
     ./patch_files.rb ~/Downloads/wells_fargo/puppet_server/*.json
 
 The tool will create new files alongside the originals with the prefix "patched."
+
+### Export metrics to Graphite
+
+For large datasets collected from customers in the form of JSON files, it may be desirable to export the data to graphite. The `export_to_graphite.rb` script can be used to transform data in the JSON files into a format that can be fed into Graphite.
+
+There is a simple Grafana dashboard JSON file included as well: `grafana-dashboard.json`
+
+Usage:
+
+    ./export_to_graphite.rb [filename_1 ... filename_n]
+
+Output will be lines in Graphite's plain text input format. This output can be fed through a tool like `nc` to inject it into Graphite.
+
+Examples:
+
+    ./export_to_graphite.rb ~/Downloads/wells_fargo/puppet_server/*.json | nc localhost 2003
+
+The simple example can be used for small numbers of files. When more files exist than can be referenced as arguments, use xargs.
+
+    find ~/Downloads/wells_fargo/puppet_server -name '*.json' | xargs ./export_to_graphite.rb | nc localhost 2003
 
 ### TODO LIST
 

--- a/export_to_graphite.rb
+++ b/export_to_graphite.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'time'
+
+def get_timestamp(str)
+  # Example filename: nzxppc5047.nndc.kp.org-11_29_16_13:00.json
+  timestr = str.match(/(\d\d)_(\d\d)_(\d\d)_(\d\d:\d\d)/)
+  yyyy = timestr[3].sub(/.*_(\d\d)$/, '20\1')
+  mm = timestr[1]
+  dd = timestr[2]
+  hhmm = timestr[4]
+  Time.parse("#{yyyy}-#{mm}-#{dd} #{hhmm}")
+end
+
+def metrics(data, timestamp, parent_key = nil)
+  data.collect do |key, value|
+    current_key = [parent_key, key].compact.join('.')
+    case value
+    when Hash
+      metrics(value, timestamp, current_key)
+    when Array
+      # Not implemented; we simply won't include these metrics in the export
+      nil
+    else
+      "#{current_key} #{value} #{timestamp.to_i}"
+    end
+  end.flatten.compact
+end
+
+while filename = ARGV.shift
+  begin
+    data = JSON.parse(File.read(filename))
+    timestamp = get_timestamp(filename)
+    graphite_data = metrics(data, timestamp)
+    puts graphite_data
+  rescue Exception => e
+    STDERR.puts "ERROR: #{filename}: #{e.message}"
+    next
+  end
+end

--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -1,0 +1,426 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_GRAPHITE",
+      "label": "Graphite",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "graphite",
+      "pluginName": "Graphite"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.0.0-pre1"
+    },
+    {
+      "type": "datasource",
+      "id": "graphite",
+      "name": "Graphite",
+      "version": "1.0.0"
+    }
+  ],
+  "id": null,
+  "title": "Puppetserver",
+  "tags": [],
+  "style": "dark",
+  "timezone": "browser",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "rows": [
+    {
+      "title": "New row",
+      "height": "250px",
+      "editable": true,
+      "collapse": false,
+      "panels": [
+        {
+          "title": "Panel Title",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "isNew": true,
+          "id": 2,
+          "targets": [
+            {
+              "target": "pe-jruby-metrics.status.experimental.metrics.average-free-jrubies",
+              "refId": "A"
+            }
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "renderer": "flot",
+          "yaxes": [
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            },
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "alert": {
+            "warn": {
+              "op": ">"
+            },
+            "crit": {
+              "op": ">"
+            }
+          },
+          "lines": true,
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": true,
+            "sort": 0,
+            "msResolution": false
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "alerting": {},
+          "thresholds": []
+        }
+      ]
+    },
+    {
+      "title": "New row",
+      "height": "250px",
+      "editable": true,
+      "collapse": false,
+      "panels": [
+        {
+          "title": "Panel Title",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "isNew": true,
+          "id": 3,
+          "targets": [
+            {
+              "target": "pe-jruby-metrics.status.experimental.metrics.average-requested-jrubies",
+              "refId": "A",
+              "hide": false
+            }
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "renderer": "flot",
+          "yaxes": [
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            },
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "alert": {
+            "warn": {
+              "op": ">"
+            },
+            "crit": {
+              "op": ">"
+            }
+          },
+          "lines": true,
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": true,
+            "sort": 0,
+            "msResolution": false
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "alerting": {},
+          "thresholds": []
+        }
+      ]
+    },
+    {
+      "title": "New row",
+      "height": "250px",
+      "editable": true,
+      "collapse": false,
+      "panels": [
+        {
+          "title": "Panel Title",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "isNew": true,
+          "id": 4,
+          "targets": [
+            {
+              "target": "pe-jruby-metrics.status.experimental.metrics.average-wait-time",
+              "refId": "A"
+            }
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "renderer": "flot",
+          "yaxes": [
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            },
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "alert": {
+            "warn": {
+              "op": ">"
+            },
+            "crit": {
+              "op": ">"
+            }
+          },
+          "lines": true,
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": true,
+            "sort": 0,
+            "msResolution": false
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "alerting": {},
+          "thresholds": []
+        }
+      ]
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "alert": {
+            "crit": {
+              "op": ">"
+            },
+            "warn": {
+              "op": ">"
+            }
+          },
+          "alerting": {},
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_GRAPHITE}",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "hideTimeOverride": false,
+          "id": 1,
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "pe-jruby-metrics.status.experimental.metrics.average-borrow-time"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": "16d",
+          "timeShift": null,
+          "title": "Panel Title",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "showTitle": false,
+      "title": "Row1"
+    }
+  ],
+  "time": {
+    "from": "2016-12-07T09:48:06.923Z",
+    "to": "2016-12-10T12:51:44.387Z"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "refresh": false,
+  "schemaVersion": 13,
+  "version": 5,
+  "links": [],
+  "gnetId": null
+}


### PR DESCRIPTION
Sometimes you want to zoom in on specific data ranges, and the simple
images won't help with that. This commit adds a simple script to convert
the JSON files to a format that can be fed into Graphite.

A stub Grafana dashboard export is included as well.