### PR TITLE
Untar any files created from pe_metric_curl_cron_jobs

### DIFF
--- a/view-in-grafana.sh
+++ b/view-in-grafana.sh
@@ -34,6 +34,7 @@ done
 echo "ready"
 
 echo -n "Loading data..."
+find $datadir -type f -iname "*.bz2" -exec bash -c 'tar jxf "{}" -C $(dirname "{}")' \; 2>/dev/null;
 ../json2graphite.rb --pattern "$datadir/"'**/*.json' --netcat localhost
 echo " loaded"
 


### PR DESCRIPTION
In order to use the compression proposed in npwalker/pe_metric_curl_cron_jobs/15, this command should be able to decompress any tar.bz2 files that have been input. This basic PR allows for the deployment script to extract the tar.bz2 files in place prior to including the json files. 